### PR TITLE
(feat) Put the root path behind SSO

### DIFF
--- a/app.py
+++ b/app.py
@@ -317,6 +317,8 @@ def proxy_app(
             }
 
     app = Flask('app')
+
+    app.add_url_rule('/', view_func=proxy, defaults={'path': '/'})
     app.add_url_rule('/<path:path>', view_func=proxy)
     server = WSGIServer(('0.0.0.0', port), app, handler_class=RequestLinePathHandler)
 

--- a/test.py
+++ b/test.py
@@ -811,6 +811,22 @@ class TestS3Proxy(unittest.TestCase):
                 session.get(f'http://127.0.0.1:8080/{key}') as response:
             self.assertEqual(response.status_code, 404)
 
+    def test_root_path_redirects_to_sso(self):
+        wait_until_started, stop_application = create_application(8080)
+        self.addCleanup(stop_application)
+        wait_until_started()
+        wait_until_sso_started, stop_sso = create_sso()
+        self.addCleanup(stop_sso)
+        wait_until_sso_started()
+
+        url_1 = f'http://localhost:8080/'
+        with requests.get(url_1, allow_redirects=False) as resp:
+            status_code = resp.status_code
+            url = resp.headers['location']
+
+        self.assertEqual(status_code, 302)
+        self.assertTrue(url.startswith('http://127.0.0.1:8081/o/authorize/'))
+
     def test_healthcheck(self):
         healthcheck_key = str(uuid.uuid4())
 


### PR DESCRIPTION
It was returning a 404. While this is safe, it means that it appears the
application is not protected.