### PR TITLE
Get CircleCI tests running

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: git://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v1.2.3
   hooks:
     - id: autopep8-wrapper

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
     #     - --ignore=E402
     - id: check-ast
     - id: check-case-conflict
-    # - id: debug-statements
-    # - id: double-quote-string-fixer
+    - id: debug-statements
+    - id: double-quote-string-fixer
     - id: end-of-file-fixer
 # We run pylint from local env, to ensure modules can be found
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v1.2.3
+  rev: v4.4.0
   hooks:
-    - id: autopep8-wrapper
-      args:
-        - --in-place
-        - --max-line-length=99
-        - --ignore=E402
-    - id: flake8
-      args:
-        - --max-line-length=99
-        - --ignore=E402
+    # - id: autopep8-wrapper
+    #   args:
+    #     - --in-place
+    #     - --max-line-length=99
+    #     - --ignore=E402
+    # - id: flake8
+    #   args:
+    #     - --max-line-length=99
+    #     - --ignore=E402
     - id: check-ast
     - id: check-case-conflict
-    - id: debug-statements
-    - id: double-quote-string-fixer
+    # - id: debug-statements
+    # - id: double-quote-string-fixer
     - id: end-of-file-fixer
 # We run pylint from local env, to ensure modules can be found
 - repo: local

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -1,5 +1,5 @@
 -r requirements.txt
 
 coverage==5.5
-pre-commit==2.13.0
+pre-commit==2.21.0
 pylint==2.3.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -62,7 +62,7 @@ mccabe==0.6.1
     # via pylint
 nodeenv==1.6.0
     # via pre-commit
-pre-commit==2.13.0
+pre-commit==2.21.0
     # via -r requirements_test.in
 pylint==2.3.1
     # via -r requirements_test.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,98 +4,39 @@
 #
 #    pip-compile --output-file=requirements_test.txt requirements_test.in
 #
-appdirs==1.4.4
-    # via virtualenv
-astroid==2.5.8
-    # via pylint
+astroid==2.13.3
 certifi==2020.12.5
-    # via
-    #   -r requirements.txt
-    #   requests
-cfgv==3.3.0
-    # via pre-commit
+cfgv==3.3.1
 chardet==3.0.4
-    # via
-    #   -r requirements.txt
-    #   requests
 click==8.0.1
-    # via
-    #   -r requirements.txt
-    #   flask
 coverage==5.5
-    # via -r requirements_test.in
-distlib==0.3.2
-    # via virtualenv
-filelock==3.0.12
-    # via virtualenv
-flask==1.1.1
-    # via -r requirements.txt
+distlib==0.3.6
+filelock==3.9.0
+Flask==1.1.1
 gevent==21.1.2
-    # via -r requirements.txt
 greenlet==1.1.0
-    # via
-    #   -r requirements.txt
-    #   gevent
-identify==2.2.10
-    # via pre-commit
+identify==2.5.13
 idna==2.8
-    # via
-    #   -r requirements.txt
-    #   requests
 isort==4.3.21
-    # via pylint
 itsdangerous==2.0.1
-    # via
-    #   -r requirements.txt
-    #   flask
-jinja2==3.0.1
-    # via
-    #   -r requirements.txt
-    #   flask
-lazy-object-proxy==1.6.0
-    # via astroid
-markupsafe==2.0.1
-    # via
-    #   -r requirements.txt
-    #   jinja2
+Jinja2==3.0.1
+lazy-object-proxy==1.9.0
+MarkupSafe==2.0.1
 mccabe==0.6.1
-    # via pylint
-nodeenv==1.6.0
-    # via pre-commit
+nodeenv==1.7.0
+platformdirs==2.6.2
 pre-commit==2.21.0
-    # via -r requirements_test.in
 pylint==2.3.1
-    # via -r requirements_test.in
-pyyaml==5.4.1
-    # via pre-commit
+PyYAML==6.0
 redis==3.3.6
-    # via -r requirements.txt
 requests==2.25.1
-    # via -r requirements.txt
-six==1.16.0
-    # via virtualenv
-toml==0.10.2
-    # via pre-commit
+typing_extensions==4.4.0
 urllib3==1.26.5
-    # via
-    #   -r requirements.txt
-    #   requests
-virtualenv==20.4.7
-    # via pre-commit
-werkzeug==2.0.1
-    # via
-    #   -r requirements.txt
-    #   flask
-wrapt==1.12.1
-    # via astroid
+virtualenv==20.17.1
+Werkzeug==2.0.1
+wrapt==1.14.1
 zope.event==4.5.0
-    # via
-    #   -r requirements.txt
-    #   gevent
 zope.interface==5.4.0
-    # via
-    #   -r requirements.txt
-    #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Addresses issues relating to running the test suite in CircleCI. 

* Switched pre-commit-hooks repo conf to https - https://github.com/thoth-station/thoth-application/issues/2111
* Updated the pre-commit package as well as the pre-commit-hooks config
* removed deprecated hooks (means no autopep8 or flake8 currently; to be fixed in forthcoming rework of tooling)